### PR TITLE
Support custom validation error messages

### DIFF
--- a/src/Orchestra/Support/Validator.php
+++ b/src/Orchestra/Support/Validator.php
@@ -84,15 +84,16 @@ abstract class Validator
      *
      * @param  array           $input
      * @param  string|array    $event
+     * @param  array           $messages
      * @return \Illuminate\Validation\Validator
      */
-    public function with(array $input, $events = array())
+    public function with(array $input, $events = array(), $messages = array())
     {
         $this->runQueuedOn();
 
         $rules = $this->runValidationEvents($events);
 
-        $this->resolver = V::make($input, $rules);
+        $this->resolver = V::make($input, $rules, $messages);
 
         $this->runQueuedExtend($this->resolver);
 


### PR DESCRIPTION
The [Validator::make()](http://laravel.com/api/source-class-Illuminate.Validation.Factory.html#64-102) function supports a third argument which you currently aren't passing which allows for custom validation error messages. The [documentation](http://laravel.com/docs/validation#custom-error-messages) shows why this is useful.
