### PR TITLE
Fixes memory forget

### DIFF
--- a/src/Support/Traits/DataContainerTrait.php
+++ b/src/Support/Traits/DataContainerTrait.php
@@ -118,7 +118,11 @@ trait DataContainerTrait
      */
     public function forget($key)
     {
-        Arr::forget($this->items, $key);
+        $items = $this->items;
+
+        Arr::forget($items, $key);
+
+        $this->items = $items;
     }
 
     /**


### PR DESCRIPTION
Forgetting a key doesn't actually re-set the items (even though it's passed by reference), so the item's can never actually be removed.